### PR TITLE
Various bug fixes

### DIFF
--- a/meldataset.py
+++ b/meldataset.py
@@ -247,7 +247,8 @@ class MelDataset(torch.utils.data.Dataset):
         filename = self.audio_files[index]
         if self._cache_ref_count == 0:
             audio, sampling_rate = load_wav(filename, self.sampling_rate)
-            audio = audio / MAX_WAV_VALUE
+            if np.abs(audio).max() > 1:
+                audio = audio / MAX_WAV_VALUE
             if not self.fine_tuning:
                 audio = normalize(audio) * 0.95
             self.cached_wav = audio
@@ -328,13 +329,13 @@ class MelDataset(torch.utils.data.Dataset):
                         * self.hop_size : (mel_start + frames_per_seg)
                         * self.hop_size,
                     ]
-                else:
-                    mel = torch.nn.functional.pad(
-                        mel, (0, frames_per_seg - mel.size(2)), "constant"
-                    )
-                    audio = torch.nn.functional.pad(
-                        audio, (0, self.segment_size - audio.size(1)), "constant"
-                    )
+
+                mel = torch.nn.functional.pad(
+                    mel, (0, frames_per_seg - mel.size(2)), "constant"
+                )
+                audio = torch.nn.functional.pad(
+                    audio, (0, self.segment_size - audio.size(1)), "constant"
+                )
 
         mel_loss = mel_spectrogram(
             audio,


### PR DESCRIPTION
I was finetuning the models on my own datasets and it failed due to a couple of bugs. This pull request fixes these issues:

- only divide by MAX_WAV_VALUE if the wav file is saved as int16 (and not float).
- always try to pad to the length of `frames_per_seg` or `self.segment_size`. It can happen that `audio.size(1) < frames_per_seg * self.hop_size`
- first comes tqdm, then enumerate, otherwise tqdm is not able to get the length attribute
- Make sure that `y_mel`, `y_g_hat_mel`, `y_g_hat`, `y_g_hat_mel` are the same length. I think the issue is that sometimes my wav files have uneven length.