### PR TITLE
Fix _from_pretrained signature for huggingface_hub>=0.23 compatibility

### DIFF
--- a/bigvgan.py
+++ b/bigvgan.py
@@ -419,8 +419,8 @@ class BigVGAN(
         revision: str,
         cache_dir: str,
         force_download: bool,
-        proxies: Optional[Dict],
-        resume_download: bool,
+        proxies: Optional[Dict] = None,
+        resume_download: bool = False,
         local_files_only: bool,
         token: Union[str, bool, None],
         map_location: str = "cpu",  # Additional argument
@@ -430,6 +430,23 @@ class BigVGAN(
     ):
         """Load Pytorch pretrained weights and return the loaded model."""
 
+        # Build kwargs for hf_hub_download, excluding params removed in huggingface_hub 1.0
+        hf_hub_kwargs = dict(
+            revision=revision,
+            cache_dir=cache_dir,
+            force_download=force_download,
+            token=token,
+            local_files_only=local_files_only,
+        )
+        # proxies and resume_download were removed in huggingface_hub 1.0
+        # Only include them for backwards compatibility with older versions
+        import inspect
+        hf_download_params = inspect.signature(hf_hub_download).parameters
+        if "proxies" in hf_download_params:
+            hf_hub_kwargs["proxies"] = proxies
+        if "resume_download" in hf_download_params:
+            hf_hub_kwargs["resume_download"] = resume_download
+
         # Download and load hyperparameters (h) used by BigVGAN
         if os.path.isdir(model_id):
             print("Loading config.json from local directory")
@@ -438,13 +455,7 @@ class BigVGAN(
             config_file = hf_hub_download(
                 repo_id=model_id,
                 filename="config.json",
-                revision=revision,
-                cache_dir=cache_dir,
-                force_download=force_download,
-                proxies=proxies,
-                resume_download=resume_download,
-                token=token,
-                local_files_only=local_files_only,
+                **hf_hub_kwargs,
             )
         h = load_hparams_from_json(config_file)
 
@@ -470,13 +481,7 @@ class BigVGAN(
             model_file = hf_hub_download(
                 repo_id=model_id,
                 filename="bigvgan_generator.pt",
-                revision=revision,
-                cache_dir=cache_dir,
-                force_download=force_download,
-                proxies=proxies,
-                resume_download=resume_download,
-                token=token,
-                local_files_only=local_files_only,
+                **hf_hub_kwargs,
             )
 
         checkpoint_dict = torch.load(model_file, map_location=map_location)


### PR DESCRIPTION
BigVGAN’s requirements.txt specifies huggingface_hub>=0.23.4, but the _from_pretrained method in bigvgan.py still uses the older signature from pre‑0.20 versions of the HuggingFace Hub API.
This causes the following error when calling BigVGAN.from_pretrained():

TypeError: BigVGAN._from_pretrained() missing 2 required keyword-only arguments: 'proxies' and 'resume_download'

This PR updates the method signature to match the current ModelHubMixin API. The fix is minimal and restores compatibility with the required HF Hub version.

Testing
- Verified locally in a clean environment
- from_pretrained() now loads models without error
- No other functionality affected
